### PR TITLE
Add registration screen

### DIFF
--- a/back/src/features/auth/auth.controller.js
+++ b/back/src/features/auth/auth.controller.js
@@ -1,19 +1,43 @@
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
 const User = require('./user.model.js');
+const Student = require('../students/student.model.js');
 
 const register = async (req, res) => {
-  const { username, password, studentId } = req.body;
+  const {
+    username,
+    password,
+    studentId,
+    firstName,
+    lastName,
+    studentNumber,
+  } = req.body;
+
   if (!username || !password) {
     return res.status(400).json({ message: 'Username and password are required.' });
   }
 
   try {
-    const passwordHash = await bcrypt.hash(password, 10); // Hash the password
-    const newUser = { username, passwordHash, role: 'student', studentId }; // Default role is student
-    
+    let newStudentId = studentId;
+
+    // If studentId is not provided, create a new student record
+    if (!newStudentId) {
+      if (!firstName || !lastName || !studentNumber) {
+        return res.status(400).json({ message: 'Student information is incomplete.' });
+      }
+
+      newStudentId = await Student.create({
+        firstName,
+        lastName,
+        studentNumber,
+      });
+    }
+
+    const passwordHash = await bcrypt.hash(password, 10);
+    const newUser = { username, passwordHash, role: 'student', studentId: newStudentId };
+
     const newUserId = await User.create(newUser);
-    res.status(201).json({ id: newUserId, username });
+    res.status(201).json({ id: newUserId, username, studentId: newStudentId });
   } catch (error) {
     res.status(500).json({ message: 'Error registering user', error: error.message });
   }

--- a/gui/src/App.jsx
+++ b/gui/src/App.jsx
@@ -1,14 +1,16 @@
 import { Routes, Route } from 'react-router-dom';
-import ProtectedRoute from './components/ProtectedRoute.jsx'; 
+import ProtectedRoute from './components/ProtectedRoute.jsx';
 import Layout from './components/Layout'; // Import the Layout component
 import LoginPage from './pages/Login';
+import RegisterPage from './pages/Register.jsx';
 import BookListPage from './pages/BookList'; // Import the new page
-import MyCheckoutsPage from './pages/MyCheckoutsPage.jsx'; 
+import MyCheckoutsPage from './pages/MyCheckoutsPage.jsx';
 
 function App() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
 
       <Route element={<ProtectedRoute />}>
         <Route element={<Layout />}>

--- a/gui/src/pages/Login.jsx
+++ b/gui/src/pages/Login.jsx
@@ -77,6 +77,9 @@ function LoginPage() {
           <Button fullWidth mt="xl" type="submit" loading={loading}>
             Giriş Yap
           </Button>
+          <Button variant="subtle" fullWidth mt="sm" onClick={() => navigate('/register')}>
+            Kaydol
+          </Button>
         </Paper>
       </Container>
     </Center>

--- a/gui/src/pages/Register.jsx
+++ b/gui/src/pages/Register.jsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { TextInput, PasswordInput, Button, Paper, Title, Container, Center, Alert } from '@mantine/core';
+import { IconAlertCircle } from '@tabler/icons-react';
+import { notifications } from '@mantine/notifications';
+
+function RegisterPage() {
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [studentNumber, setStudentNumber] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const navigate = useNavigate();
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    try {
+      // 1. Create student record
+      const studentRes = await fetch('http://localhost:3000/api/students', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName,
+          lastName,
+          studentNumber,
+        }),
+      });
+      const studentData = await studentRes.json();
+      if (!studentRes.ok) {
+        throw new Error(studentData.message || 'Öğrenci oluşturulamadı.');
+      }
+
+      // 2. Create user linked to the student
+      const userRes = await fetch('http://localhost:3000/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          username,
+          password,
+          studentId: studentData.id,
+        }),
+      });
+      const userData = await userRes.json();
+      if (!userRes.ok) {
+        throw new Error(userData.message || 'Kullanıcı oluşturulamadı.');
+      }
+
+      notifications.show({
+        title: 'Başarılı!',
+        message: 'Kayıt işlemi tamamlandı. Giriş yapabilirsiniz.',
+        color: 'green',
+      });
+      navigate('/login');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Center style={{ height: '100vh' }}>
+      <Container size={420} my={40}>
+        <Title align="center" order={1} mb="md">
+          Kayıt Ol
+        </Title>
+        <Paper withBorder shadow="md" p={30} radius="md" component="form" onSubmit={handleSubmit}>
+          {error && (
+            <Alert icon={<IconAlertCircle size="1rem" />} title="Hata!" color="red" mb="md">
+              {error}
+            </Alert>
+          )}
+          <TextInput
+            label="Ad"
+            placeholder="Adınız"
+            required
+            value={firstName}
+            onChange={(e) => setFirstName(e.currentTarget.value)}
+          />
+          <TextInput
+            label="Soyad"
+            placeholder="Soyadınız"
+            required
+            mt="md"
+            value={lastName}
+            onChange={(e) => setLastName(e.currentTarget.value)}
+          />
+          <TextInput
+            label="Öğrenci No"
+            placeholder="Öğrenci numaranız"
+            required
+            mt="md"
+            value={studentNumber}
+            onChange={(e) => setStudentNumber(e.currentTarget.value)}
+          />
+          <TextInput
+            label="Kullanıcı Adı"
+            placeholder="Kullanıcı adınız"
+            required
+            mt="md"
+            value={username}
+            onChange={(e) => setUsername(e.currentTarget.value)}
+          />
+          <PasswordInput
+            label="Parola"
+            placeholder="Parolanız"
+            required
+            mt="md"
+            value={password}
+            onChange={(e) => setPassword(e.currentTarget.value)}
+          />
+          <Button fullWidth mt="xl" type="submit" loading={loading}>
+            Kayıt Ol
+          </Button>
+        </Paper>
+      </Container>
+    </Center>
+  );
+}
+
+export default RegisterPage;


### PR DESCRIPTION
## Summary
- create `/register` page with student and user forms
- link to registration from login page
- extend backend register API to optionally create new student record

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ae6746ed0833285d5cf5329bb5cde